### PR TITLE
Configurable reward system

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,18 +11,18 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'net.minecraftforge.gradle:ForgeGradle:1.1-SNAPSHOT'
+        classpath 'net.minecraftforge.gradle:ForgeGradle:1.2-SNAPSHOT'
     }
 }
 
 apply plugin: 'forge'
 
-version = "1.4.7"
+version = "1.7.10-1.4.8"
 group= "minesweeperMod" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = "Minesweeper Mod"
 
 minecraft {
-    version = "1.7.2-10.12.0.1047"
+    version = "1.7.10-10.13.2.1291"
     assetDir = "../minecraft/assets"
 }
 // configure the source folders

--- a/src/minesweeperMod/common/BlockMinesweeper.java
+++ b/src/minesweeperMod/common/BlockMinesweeper.java
@@ -2,7 +2,9 @@ package minesweeperMod.common;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map.Entry;
 import java.util.Random;
+import java.util.TreeMap;
 
 import minesweeperMod.client.FieldStatHandler;
 import minesweeperMod.common.network.PacketSpawnParticle;
@@ -13,11 +15,12 @@ import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.item.EntityXPOrb;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
-import net.minecraft.init.Items;
-import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.World;
+import net.minecraftforge.common.config.ConfigCategory;
+import net.minecraftforge.common.config.Configuration;
+import net.minecraftforge.common.config.Property;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
@@ -165,7 +168,6 @@ public class BlockMinesweeper extends Block{
 
     public boolean isGameDoneAndReward(World world, int x, int y, int z, EntityPlayer player){
         List<int[]> list = new ArrayList<int[]>();
-        Random rand = new Random();
         getAccessoryTiles(list, world, x, y, z);
         int tileCount = list.size();
         int bombCount = 0;
@@ -181,99 +183,89 @@ public class BlockMinesweeper extends Block{
         }
 
         if(tileCount > 50) player.triggerAchievement(MinesweeperUtils.getAchieveFromName("achieveCleared1"));
-        else return true;
         if(tileCount > 100) player.triggerAchievement(MinesweeperUtils.getAchieveFromName("achieveCleared2"));
         if(tileCount > 200) player.triggerAchievement(MinesweeperUtils.getAchieveFromName("achieveCleared3"));
         if(tileCount > 500) player.triggerAchievement(MinesweeperUtils.getAchieveFromName("achieveCleared4"));
         if(tileCount > 1000) player.triggerAchievement(MinesweeperUtils.getAchieveFromName("achieveCleared5"));
 
         // reward the player depending on how many tiles have been cleared.
-        Item item = null;
-        int itemAmount = 1; // drop default one item.
-        int itemDamage = 0;
         double tileBombRatio = (double)bombCount / (double)tileCount;
         double hardcoreBombPercentage = (double)hardcoreBombCount / (double)bombCount;
-        // TODO improve rewards
+        ItemStack[] iStack = null;
         if(tileBombRatio > 1D / 6D && hardcoreBombPercentage > 0.5D) {
             // hardcore rewards:
             player.triggerAchievement(MinesweeperUtils.getAchieveFromName("achieveDifficulty4"));
-            if(tileCount > 500) {
-                item = Items.nether_star;
-            } else if(tileCount > 300) {
-                item = Item.getItemFromBlock(Blocks.emerald_block);
-            } else if(tileCount > 200) {
-                item = Item.getItemFromBlock(Blocks.diamond_block);
-            } else if(tileCount > 100) {
-                item = Item.getItemFromBlock(Blocks.gold_block);
-            } else if(tileCount > 50) {
-                item = Item.getItemFromBlock(Blocks.iron_block);
-            } else {
-                return true;
-            }
+            iStack = getReward(Constants.LOOT_TABLE_HARDCORE_CATEGORY, tileCount);
         } else if(tileBombRatio > 1D / 6D) {
             // hard rewards:
             player.triggerAchievement(MinesweeperUtils.getAchieveFromName("achieveDifficulty3"));
-            itemAmount = rand.nextInt(3) + 3;// 3 to 5 drops
-            if(tileCount > 500) {
-                item = Items.skull;
-                itemDamage = 1;
-                itemAmount = 1; // one skull drop per.
-            } else if(tileCount > 300) {
-                item = Items.emerald;
-            } else if(tileCount > 200) {
-                item = Items.diamond;
-            } else if(tileCount > 100) {
-                item = Item.getItemFromBlock(Blocks.glowstone);
-            } else if(tileCount > 50) {
-                item = Items.glowstone_dust;
-            } else {
-                return true;
-            }
+            iStack = getReward(Constants.LOOT_TABLE_HARD_CATEGORY, tileCount);
         } else if(tileBombRatio > 1D / 8D) {
             // normal rewards:
             player.triggerAchievement(MinesweeperUtils.getAchieveFromName("achieveDifficulty2"));
-            itemAmount = rand.nextInt(3) + 3;// 3 to 5 drops
-            if(tileCount > 500) {
-                item = Items.emerald;
-            } else if(tileCount > 300) {
-                item = Items.diamond;
-            } else if(tileCount > 200) {
-                item = Items.glowstone_dust;
-            } else if(tileCount > 100) {
-                item = Items.redstone;
-            } else if(tileCount > 50) {
-                item = Items.gold_ingot;
-            } else {
-                return true;
-            }
+            iStack = getReward(Constants.LOOT_TABLE_NORMAL_CATEGORY, tileCount);
         } else {
             // easy rewards:
             player.triggerAchievement(MinesweeperUtils.getAchieveFromName("achieveDifficulty1"));
-            itemAmount = rand.nextInt(3) + 1; // 1 to 3 drops
-            if(tileCount > 500) {
-                item = Items.diamond;
-            } else if(tileCount > 300) {
-                item = Items.glowstone_dust;
-            } else if(tileCount > 200) {
-                item = Items.redstone;
-            } else if(tileCount > 100) {
-                item = Items.gold_ingot;
-            } else if(tileCount > 50) {
-                item = Items.iron_ingot;
-            } else {
-                return true;
+            iStack = getReward(Constants.LOOT_TABLE_EASY_CATEGORY, tileCount);
+        }
+
+        if (iStack == null) {
+            return true;
+        }
+        
+        for (int i = 0; i < iStack.length; i++) {
+	        float var6 = 0.7F;
+	        double var7 = world.rand.nextFloat() * var6 + (1.0F - var6) * 0.5D;
+	        double var9 = world.rand.nextFloat() * var6 + (1.0F - var6) * 0.5D;
+	        double var11 = world.rand.nextFloat() * var6 + (1.0F - var6) * 0.5D;
+	        EntityItem var13 = new EntityItem(world, x + var7, y + 1D + var9, z + var11, iStack[i]);
+	        var13.delayBeforeCanPickup = 10;
+	        world.spawnEntityInWorld(var13);
+        }
+        return true;
+    }
+
+    private ItemStack[] getReward(String difficulty, int tileCount) {
+        Configuration config = new Configuration(MinesweeperMod.configFile);
+        ConfigCategory category = config.getCategory(difficulty);
+        TreeMap<Integer, Property> difficultyRewards = new TreeMap<Integer, Property>();
+        for (Entry<String, Property> entry : category.getValues().entrySet()) {
+            difficultyRewards.put(Integer.parseInt(entry.getKey()), entry.getValue());
+        }
+
+        Entry<Integer, Property> rewardEntry = difficultyRewards.floorEntry(tileCount);
+        if (rewardEntry == null) {
+            return null;
+        }
+
+        String[] rewardConfig = rewardEntry.getValue().getStringList();
+        Reward[] rewards = new Reward[rewardConfig.length];
+        for (int i = 0; i < rewardConfig.length; i++) {
+            rewards[i] = new Reward(rewardConfig[i]);
+        }
+        
+        int totalWeight = 0;
+        for (Reward reward : rewards) {
+            totalWeight += reward.getWeight();
+        }
+        
+        int randomIndex = -1;
+        double random = Math.random() * totalWeight;
+        for (int i = 0; i < rewards.length; ++i) {
+            random -= rewards[i].getWeight();
+            if (random <= 0.0d) {
+                randomIndex = i;
+                break;
             }
         }
-        ItemStack iStack = new ItemStack(item, itemAmount, itemDamage);
+        if (randomIndex == -1) {
+            return null;
+        }
+        
+        Reward reward = rewards[randomIndex];
 
-        float var6 = 0.7F;
-        double var7 = world.rand.nextFloat() * var6 + (1.0F - var6) * 0.5D;
-        double var9 = world.rand.nextFloat() * var6 + (1.0F - var6) * 0.5D;
-        double var11 = world.rand.nextFloat() * var6 + (1.0F - var6) * 0.5D;
-        EntityItem var13 = new EntityItem(world, x + var7, y + 1D + var9, z + var11, iStack);
-        var13.delayBeforeCanPickup = 10;
-        world.spawnEntityInWorld(var13);
-        return true;
+        return reward.getReward();
     }
 
     public void eraseField(World world, int x, int y, int z, boolean explodeOnHardcore){

--- a/src/minesweeperMod/common/BlockMinesweeper.java
+++ b/src/minesweeperMod/common/BlockMinesweeper.java
@@ -240,6 +240,9 @@ public class BlockMinesweeper extends Block{
         }
 
         String[] rewardConfig = rewardEntry.getValue().getStringList();
+        if (rewardConfig.length == 0) {
+        	return null;
+        }
         Reward[] rewards = new Reward[rewardConfig.length];
         for (int i = 0; i < rewardConfig.length; i++) {
             rewards[i] = new Reward(rewardConfig[i]);
@@ -252,7 +255,7 @@ public class BlockMinesweeper extends Block{
         
         int randomIndex = -1;
         double random = Math.random() * totalWeight;
-        for (int i = 0; i < rewards.length; ++i) {
+        for (int i = 0; i < rewards.length; i++) {
             random -= rewards[i].getWeight();
             if (random <= 0.0d) {
                 randomIndex = i;

--- a/src/minesweeperMod/common/Constants.java
+++ b/src/minesweeperMod/common/Constants.java
@@ -4,4 +4,9 @@ public class Constants{
     public static final String MOD_ID = "MinesweeperMod";
 
     public static final double PACKET_UPDATE_DISTANCE = 64D;
+    
+    public static final String LOOT_TABLE_HARDCORE_CATEGORY = "loot table hardcore";
+    public static final String LOOT_TABLE_HARD_CATEGORY = "loot table hard";
+    public static final String LOOT_TABLE_NORMAL_CATEGORY = "loot table normal";
+    public static final String LOOT_TABLE_EASY_CATEGORY = "loot table easy";
 }

--- a/src/minesweeperMod/common/ForgeEventHandler.java
+++ b/src/minesweeperMod/common/ForgeEventHandler.java
@@ -1,5 +1,10 @@
 package minesweeperMod.common;
 
+import net.minecraft.block.Block;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.init.Items;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent.Action;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
@@ -13,13 +18,31 @@ import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 
 public class ForgeEventHandler{
     /**
-     * Used to open a Minesweeper block in creative, when the player is holding a sword.
+     * Used to open a Minesweeper block in creative, when the player is holding a (vanilla) sword.
      * @param event
      */
     @SubscribeEvent
     public void onPlayerClick(PlayerInteractEvent event){
-        if(event.action == Action.LEFT_CLICK_BLOCK && event.entityPlayer.worldObj.getBlock(event.x, event.y, event.z) == MinesweeperMod.blockMinesweeper) {
-            event.entityPlayer.worldObj.getBlock(event.x, event.y, event.z).onBlockClicked(event.entityPlayer.worldObj, event.x, event.y, event.z, event.entityPlayer);
+    	EntityPlayer player = event.entityPlayer;
+    	if (player.capabilities.isCreativeMode) {
+    		if (isSword(player.getCurrentEquippedItem())) {
+	    		Block block = player.worldObj.getBlock(event.x, event.y, event.z);
+	    		if(event.action == Action.LEFT_CLICK_BLOCK && block == MinesweeperMod.blockMinesweeper) {
+	        		block.onBlockClicked(player.worldObj, event.x, event.y, event.z, player);
+	        		event.setCanceled(true);
+	        	}
+    		}
         }
+    }
+    
+    private boolean isSword(ItemStack equipped) {
+    	if (equipped == null) {
+    		return false;
+    	}
+    	Item item = equipped.getItem();
+    	if (item == Items.diamond_shovel || item == Items.golden_sword || item == Items.iron_sword || item == Items.stone_sword || item == Items.wooden_sword) {
+    		return true;
+    	}
+    	return false;
     }
 }

--- a/src/minesweeperMod/common/ForgeEventHandler.java
+++ b/src/minesweeperMod/common/ForgeEventHandler.java
@@ -40,7 +40,7 @@ public class ForgeEventHandler{
     		return false;
     	}
     	Item item = equipped.getItem();
-    	if (item == Items.diamond_shovel || item == Items.golden_sword || item == Items.iron_sword || item == Items.stone_sword || item == Items.wooden_sword) {
+    	if (item == Items.diamond_sword || item == Items.golden_sword || item == Items.iron_sword || item == Items.stone_sword || item == Items.wooden_sword) {
     		return true;
     	}
     	return false;

--- a/src/minesweeperMod/common/MinesweeperMod.java
+++ b/src/minesweeperMod/common/MinesweeperMod.java
@@ -1,6 +1,10 @@
 package minesweeperMod.common;
 
 import java.io.File;
+import java.text.MessageFormat;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.regex.Pattern;
 
 import minesweeperMod.common.network.PacketPipeline;
 import minesweeperMod.common.network.PacketSpawnParticle;
@@ -130,16 +134,16 @@ public class MinesweeperMod{
 
         StringBuilder sb = new StringBuilder();
         sb.append("Loot table property names are the minimum number of tiles cleared to be eligible for the reward tier. \n");
-        sb.append("At least one tier is required and there is no limit to the number of tiers allowed.\n");
         sb.append("Syntax for rewards: \n\n");
-        sb.append("weight;modid:item_name:meta:min_stack_size:max_stack_size[;modid:item_name:meta:min_stack_size:max_stack_size[...]]\n\n");
-        sb.append("weight: determins the probablity of the reward within the tier, a higher value indicates a higher chance of the reward.\n\n");
+        sb.append("weight;mod_id:item_name:meta:min_stack_size:max_stack_size[;mod_id:item_name:meta:min_stack_size:max_stack_size[...]]\n\n");
+        sb.append("weight: determines the probability of the reward within the tier, a higher value indicates a higher chance of the reward.\n\n");
         sb.append("An example reward tier giving between 1 and 3 iron blocks and between 2 and 8 iron ingots would look like the following: \n\n");
-        sb.append("1;minecraft:iron_block:0:1:3;minecraft:iron_ingot:0:2:8");
+        sb.append("1;minecraft:iron_block:0:1:3;minecraft:iron_ingot:0:2:8\n\n");
+        sb.append("If you do not what reward items for a particular difficulty, do not declare any reward tiers for that difficulty.");
         String lootTableConfigComment = sb.toString();
         
         // Loot tables
-        if (!isLootTableConfigured(config, Constants.LOOT_TABLE_HARDCORE_CATEGORY)) {
+        if (!config.hasCategory(Constants.LOOT_TABLE_HARDCORE_CATEGORY)) {
         	configLootTable(config, Constants.LOOT_TABLE_HARDCORE_CATEGORY, 51, Blocks.iron_block);
         	configLootTable(config, Constants.LOOT_TABLE_HARDCORE_CATEGORY, 101, Blocks.gold_block);
         	configLootTable(config, Constants.LOOT_TABLE_HARDCORE_CATEGORY, 201, Blocks.diamond_block);
@@ -148,7 +152,7 @@ public class MinesweeperMod{
         }
         ConfigCategory configCategory = config.getCategory(Constants.LOOT_TABLE_HARDCORE_CATEGORY);
     	configCategory.setComment(lootTableConfigComment);
-        if (!isLootTableConfigured(config, Constants.LOOT_TABLE_HARD_CATEGORY)) {
+        if (!config.hasCategory(Constants.LOOT_TABLE_HARD_CATEGORY)) {
         	configLootTable(config, Constants.LOOT_TABLE_HARD_CATEGORY, 51, Items.glowstone_dust, 3, 5);
         	configLootTable(config, Constants.LOOT_TABLE_HARD_CATEGORY, 101, Blocks.glowstone, 3, 5);
         	configLootTable(config, Constants.LOOT_TABLE_HARD_CATEGORY, 201, Items.diamond, 3, 5);
@@ -157,7 +161,7 @@ public class MinesweeperMod{
         }
         configCategory = config.getCategory(Constants.LOOT_TABLE_HARD_CATEGORY);
     	configCategory.setComment(lootTableConfigComment);
-        if (!isLootTableConfigured(config, Constants.LOOT_TABLE_NORMAL_CATEGORY)) {
+        if (!config.hasCategory(Constants.LOOT_TABLE_NORMAL_CATEGORY)) {
         	configLootTable(config, Constants.LOOT_TABLE_NORMAL_CATEGORY, 51, Items.gold_ingot, 3, 5);
         	configLootTable(config, Constants.LOOT_TABLE_NORMAL_CATEGORY, 101, Items.redstone, 3, 5);
         	configLootTable(config, Constants.LOOT_TABLE_NORMAL_CATEGORY, 201, Items.glowstone_dust, 3, 5);
@@ -166,7 +170,7 @@ public class MinesweeperMod{
         }
         configCategory = config.getCategory(Constants.LOOT_TABLE_NORMAL_CATEGORY);
     	configCategory.setComment(lootTableConfigComment);
-        if (!isLootTableConfigured(config, Constants.LOOT_TABLE_EASY_CATEGORY)) {
+        if (!config.hasCategory(Constants.LOOT_TABLE_EASY_CATEGORY)) {
         	configLootTable(config, Constants.LOOT_TABLE_EASY_CATEGORY, 51, Items.iron_ingot, 1, 3);
         	configLootTable(config, Constants.LOOT_TABLE_EASY_CATEGORY, 101, Items.gold_ingot, 1, 3);
         	configLootTable(config, Constants.LOOT_TABLE_EASY_CATEGORY, 201, Items.redstone, 1, 3);
@@ -178,6 +182,8 @@ public class MinesweeperMod{
         
         config.save();// save the configuration file
 
+        sanityCheckRewards(config);
+        
         blockMinesweeper = new BlockMinesweeper(Material.ground).setHardness(3.0F).setResistance(1.0F).setBlockName("minesweeperBlock");// .setCreativeTab(CreativeTabs.tabBlock);
 
         itemFieldGenerator = new ItemFieldGenerator().setCreativeTab(CreativeTabs.tabTools).setUnlocalizedName("fieldGenerator");
@@ -192,19 +198,6 @@ public class MinesweeperMod{
         achievementRegisters();
     }
 
-    private boolean isLootTableConfigured(Configuration config, String category) {
-    	if (config.hasCategory(category)) {
-    		ConfigCategory configCategory = config.getCategory(category);
-    		if (configCategory.isEmpty()) {
-    			return false;
-    		} else {
-    			return true;
-    		}
-    	} else {
-    		return false;
-    	}
-    }
-    
     private void configLootTable(Configuration config, String category, int boardSize, Block block) {
     	configLootTable(config, category, boardSize, block, 1, 1);
     }
@@ -227,6 +220,85 @@ public class MinesweeperMod{
     	config.get(category, String.valueOf(boardSize), new String[]{
     			"1;" + name + ":" + meta + ":" + min + ":" + max
     	});
+    }
+    
+    private void sanityCheckRewards(Configuration config) {
+    	sanityCheckRewardDifficulty(config, Constants.LOOT_TABLE_HARDCORE_CATEGORY);
+    	sanityCheckRewardDifficulty(config, Constants.LOOT_TABLE_HARD_CATEGORY);
+    	sanityCheckRewardDifficulty(config, Constants.LOOT_TABLE_NORMAL_CATEGORY);
+    	sanityCheckRewardDifficulty(config, Constants.LOOT_TABLE_EASY_CATEGORY);
+    }
+    
+    private void sanityCheckRewardDifficulty(Configuration config, String difficulty) {
+    	ConfigCategory category = config.getCategory(difficulty);
+    	Map<String, Property> tiers = category.getValues();
+    	for (Entry<String, Property> tier : tiers.entrySet()) {
+    		try {
+    			Integer.parseInt(tier.getKey());
+    			sanityCheckRewardTier(difficulty, tier);
+    		} catch (NumberFormatException e) {
+    			StringBuilder sb = new StringBuilder();
+    			sb.append("Configuration error for {0}: Invalid reward tier ''{2}'' in ''{1}''. ");
+    			sb.append("The tier must be an integer value equal to or greater than zero");
+    			throw new RuntimeException(MessageFormat.format(sb.toString(), Constants.MOD_ID, difficulty, tier.getKey()), e);
+    		}
+    	}
+    }
+    
+    private void sanityCheckRewardTier(String difficulty, Entry<String, Property> tier) {
+    	if (tier.getValue().getStringList().length == 0) {
+    		StringBuilder sb = new StringBuilder();
+    		sb.append("Configuration error for {0}: Missing rewards in tier ''{2}'' for ''{1}''. ");
+    		sb.append("Reward tiers need at least one reward, if you do not what a reward for a specified tier, remove the tier.");
+    		throw new RuntimeException(MessageFormat.format(sb.toString(), Constants.MOD_ID, difficulty, tier.getKey()));
+    	}
+    	Pattern rewardPattern = Pattern.compile("\\d+(;\\w+:\\w+:-?\\d+:\\d+:\\d+)+");
+    	for (String reward : tier.getValue().getStringList()) {
+    		if (!rewardPattern.matcher(reward).matches()) {
+    			StringBuilder sb = new StringBuilder();
+    			sb.append("Configuration error for {0}: Invalid reward definition ''{3}'' in tier ''{2}'' for ''{1}''. ");
+    			sb.append("The reward definition must have the following format: \n");
+    			sb.append("weight;mod_id:item_name:meta:min_stack_size:max_stack_size[;mod_id:item_name:meta:min_stack_size:max_stack_size[...]]");
+    			throw new RuntimeException(MessageFormat.format(sb.toString(), Constants.MOD_ID, difficulty, tier.getKey(), reward));
+    		}
+    		String[] rewardItems = reward.split(";");
+    		int weight = Integer.parseInt(rewardItems[0]);
+    		if (weight < 1) {
+    			StringBuilder sb = new StringBuilder();
+    			sb.append("Configuration error for {0}: Invalid reward weight for ''{3}'' in tier ''{2}'' for ''{1}''. ");
+    			sb.append("Weight must be greater than or equal to one.");
+    			throw new RuntimeException(MessageFormat.format(sb.toString(), Constants.MOD_ID, difficulty, tier.getKey(), reward));
+    		}
+    		for (int i = 1; i < rewardItems.length; i++) {
+    			sanityCheckRewardItem(difficulty, tier.getKey(), rewardItems[i]);
+    			
+    		}
+    	}
+    }
+    
+    private void sanityCheckRewardItem(String difficulty, String tier, String configItem) {
+    	RewardItem rewardItem = null;
+    	try {
+    		rewardItem = new RewardItem(configItem);
+    	} catch (Exception e) {
+    		StringBuilder sb = new StringBuilder();
+    		sb.append("Configuration error for {0}: Invalid item definition ''{3}'' in tier ''{2}'' for ''{1}''. ");
+    		sb.append("Item definitions must have the following format: \n");
+    		sb.append("mod_id:item_name:meta:min_stack_size:max_stack_size");
+    		throw new RuntimeException(MessageFormat.format(sb.toString(), Constants.MOD_ID, difficulty, tier, configItem), e);
+    	}
+    	Item item = GameRegistry.findItem(rewardItem.modId, rewardItem.itemName);
+		if (item == null) {
+			StringBuilder sb = new StringBuilder();
+			sb.append("Configuration error for {0}: Unknown item ''{3}:{4}'' in tier ''{2}'' for ''{1}''. ");
+			throw new RuntimeException(MessageFormat.format(sb.toString(), Constants.MOD_ID, difficulty, tier, rewardItem.modId, rewardItem.itemName));
+		}
+		if (rewardItem.min < 0 || rewardItem.min > rewardItem.max) {
+			StringBuilder sb = new StringBuilder();
+			sb.append("Configuration error for {0}: Invalid stack size range for ''{3}'' in tier ''{2}'' for ''{3}''. ");
+			sb.append("Minimum stack size must be equal to or greater than zero and equal to or less than max stack size");
+			throw new RuntimeException(MessageFormat.format(sb.toString(), Constants.MOD_ID, difficulty, tier, configItem, rewardItem.min));
+		}
     }
     
     @EventHandler

--- a/src/minesweeperMod/common/Reward.java
+++ b/src/minesweeperMod/common/Reward.java
@@ -1,0 +1,55 @@
+package minesweeperMod.common;
+
+import java.util.Random;
+
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import cpw.mods.fml.common.registry.GameRegistry;
+
+public class Reward {
+	private int weight;
+	private RewardItem[] rewardItems;
+	
+	public Reward(String reward) {
+		String[] components = reward.split(";");
+		weight = Integer.parseInt(components[0]);
+		rewardItems = new RewardItem[components.length - 1];
+		for (int i = 0; i < rewardItems.length; i++) {
+			rewardItems[i] = new RewardItem(components[i + 1]);
+		}
+	}
+
+	public ItemStack[] getReward() {
+		ItemStack[] reward = new ItemStack[rewardItems.length];
+		for (int i = 0; i < rewardItems.length; i++) {
+			RewardItem rewardItem = rewardItems[i];
+			Item item = GameRegistry.findItem(rewardItem.modId, rewardItem.itemName);
+			Random rand = new Random();
+			int count = rand.nextInt(rewardItem.max - rewardItem.min + 1) + rewardItem.min;
+			reward[i] = new ItemStack(item, count, rewardItem.meta);
+		}
+		
+		return reward;
+	}
+
+	public int getWeight() {
+		return weight;
+	}
+	
+	private class RewardItem {
+		private String modId;
+		private String itemName;
+		private int meta;
+		private int min;
+		private int max;
+		
+		public RewardItem(String data) {
+			String[] components = data.split(":");
+			modId = components[0];
+			itemName = components[1];
+			meta = Integer.parseInt(components[2]);
+			min = Integer.parseInt(components[3]);
+			max = Integer.parseInt(components[4]);
+		}
+	}
+}

--- a/src/minesweeperMod/common/Reward.java
+++ b/src/minesweeperMod/common/Reward.java
@@ -35,21 +35,4 @@ public class Reward {
 	public int getWeight() {
 		return weight;
 	}
-	
-	private class RewardItem {
-		private String modId;
-		private String itemName;
-		private int meta;
-		private int min;
-		private int max;
-		
-		public RewardItem(String data) {
-			String[] components = data.split(":");
-			modId = components[0];
-			itemName = components[1];
-			meta = Integer.parseInt(components[2]);
-			min = Integer.parseInt(components[3]);
-			max = Integer.parseInt(components[4]);
-		}
-	}
 }

--- a/src/minesweeperMod/common/RewardItem.java
+++ b/src/minesweeperMod/common/RewardItem.java
@@ -1,0 +1,18 @@
+package minesweeperMod.common;
+
+public class RewardItem {
+	public String modId;
+	public String itemName;
+	public int meta;
+	public int min;
+	public int max;
+	
+	public RewardItem(String data) {
+		String[] components = data.split(":");
+		modId = components[0];
+		itemName = components[1];
+		meta = Integer.parseInt(components[2]);
+		min = Integer.parseInt(components[3]);
+		max = Integer.parseInt(components[4]);
+	}
+}


### PR DESCRIPTION
- Fixed issue with duplicate rewards being generated due to the click handler for a creative player. I also brought the code inline with the comment which states that creative players should use a sword to play the minesweeper game.
- I added a configuration based rewards system. The default rewards are the same as they were previously. The system works as follows:
  - Each difficulty level has a separate list of reward tiers, tiers are determined by the number of tiles on the board. These can all be customized to any number of tiles, by default it uses the same values as before.
  - Each tier as a weighted list of rewards, a higher weight results in a higher chance of getting that reward for that tier.
  - Each reward can have one or more items, specified by ModId, item name and meta/damage value.
  - Each item can also specify a minimum and maximum count, which is randomly selected.
